### PR TITLE
Removed: useless `parse` import from `path` module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // Native
 const { createServer } = require('http')
-const { join, parse, isAbsolute, normalize } = require('path')
+const { join, isAbsolute, normalize } = require('path')
 
 // Packages
 const { app, protocol } = require('electron')


### PR DESCRIPTION
Since parse is not used in index.js, this will make CI tests pass again and your PR may be merged afterward.